### PR TITLE
content: clear the em dash from the two catalog descriptions that render

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,12 +1,12 @@
 {
   "version": "1.0",
-  "generatedAt": "2026-09-08T18:48:32.625Z",
+  "generatedAt": "2026-09-10T13:27:19.991Z",
   "items": [
     {
       "id": "LGJ-graphics",
       "type": "skill",
       "name": "LGJ-graphics",
-      "description": "Lead Gen Jay brand illustration style system — flat SVG with floating UI elements, 30 brand logos, shared component library, Framer Motion animations, and consistent design tokens.",
+      "description": "Lead Gen Jay brand illustration style system, built on flat SVG with floating UI elements, 30 brand logos, shared component library, Framer Motion animations, and consistent design tokens.",
       "categories": [
         "design",
         "illustration",
@@ -1063,7 +1063,7 @@
       "id": "notes",
       "type": "command",
       "name": "notes",
-      "description": "Interactive markdown review toolkit — open any file in the claude-review web UI to leave inline comments, then have Claude address each thread with edits or replies. Bundles /notes, /cr-review, and /cr-address. Currently macOS Apple Silicon only.",
+      "description": "Interactive markdown review toolkit. Open any file in the claude-review web UI to leave inline comments, then have Claude address each thread with edits or replies. Bundles /notes, /cr-review, and /cr-address. Currently macOS Apple Silicon only.",
       "categories": [
         "productivity",
         "content"

--- a/commands/notes/manifest.yaml
+++ b/commands/notes/manifest.yaml
@@ -1,5 +1,5 @@
 name: notes
-description: Interactive markdown review toolkit — open any file in the claude-review web UI to leave inline comments, then have Claude address each thread with edits or replies. Bundles /notes, /cr-review, and /cr-address. Currently macOS Apple Silicon only.
+description: Interactive markdown review toolkit. Open any file in the claude-review web UI to leave inline comments, then have Claude address each thread with edits or replies. Bundles /notes, /cr-review, and /cr-address. Currently macOS Apple Silicon only.
 categories:
   - productivity
   - content

--- a/skills/LGJ-graphics/manifest.yaml
+++ b/skills/LGJ-graphics/manifest.yaml
@@ -1,5 +1,5 @@
 name: LGJ-graphics
-description: Lead Gen Jay brand illustration style system — flat SVG with floating UI elements, 30 brand logos, shared component library, Framer Motion animations, and consistent design tokens.
+description: Lead Gen Jay brand illustration style system, built on flat SVG with floating UI elements, 30 brand logos, shared component library, Framer Motion animations, and consistent design tokens.
 categories:
   - design
   - illustration


### PR DESCRIPTION
## Why

The `/skills/[id]` walkthrough on leadgenjay.com found em dashes in 21 browser tab titles. Nineteen came from the marketplace repo's own supplementary catalogs and were fixed there (web-builder #754, live). These two resolve from **this** repo's `catalog.json` instead, so they survived and are still live in search results.

`LGJ-graphics` and `notes` are the only two entries here that render their own detail page. Their `description` reaches the page `<title>`, the `h1`, the meta description and the JSON-LD.

| | before | after |
|---|---|---|
| `LGJ-graphics` | Lead Gen Jay brand illustration style system / flat SVG with floating UI elements... | `...style system, built on flat SVG with floating UI elements...` |
| `notes` | Interactive markdown review toolkit / open any file in the claude-review web UI... | `Interactive markdown review toolkit. Open any file in the claude-review web UI...` |

## How

Edited at the source, `manifest.yaml`, not in the generated file:

- `skills/LGJ-graphics/manifest.yaml`
- `commands/notes/manifest.yaml`

then `node scripts/generate-catalog.js`. The regenerated `catalog.json` differs in exactly three lines: `generatedAt` and the two descriptions. Nothing else churned, which also confirms the checkout was in sync with the committed file.

Neither replacement introduces a colon, because these are unquoted YAML scalars and a colon would break parsing.

## Deliberately left alone

Eight further entries carry em dashes: the `LGJ-n8n-*` skills. They are hidden, so only the bundle pack renders a page and none of those strings reaches a title. Jay's call, 2026-09-10.

Both humanizer scanners are clean on the two new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
